### PR TITLE
Add error messages for incomplete parsing

### DIFF
--- a/Text/Boomerang/Error.hs
+++ b/Text/Boomerang/Error.hs
@@ -33,6 +33,7 @@ type instance Pos (ParserError p) = p
 
 instance ErrorPosition (ParserError p) where
     getPosition (ParserError mPos _) = mPos
+    setPosition mPos (ParserError _ msg) = ParserError (Just mPos) msg
 
 {-
 instance ErrorList ParserError where

--- a/Text/Boomerang/Pos.hs
+++ b/Text/Boomerang/Pos.hs
@@ -16,6 +16,7 @@ type family Pos err :: *
 -- | extract the position information from an error
 class ErrorPosition err where
     getPosition :: err -> Maybe (Pos err)
+    setPosition :: Pos err -> err -> err
 
 -- | the initial position for a position type
 class InitialPosition e where

--- a/Text/Boomerang/Prim.hs
+++ b/Text/Boomerang/Prim.hs
@@ -18,6 +18,7 @@ import Control.Monad       (MonadPlus(mzero, mplus), ap)
 import Control.Monad.Error (Error(..))
 import Data.Either         (partitionEithers)
 import Data.Function       (on)
+import Data.List           (partition)
 import Data.Monoid         (Monoid(mappend, mempty))
 import qualified Data.Semigroup as SG
 import Text.Boomerang.HStack   ((:-)(..), hdMap, hdTraverse)
@@ -159,19 +160,34 @@ val rs ss = Boomerang rs' ss'
       ss' =  (\(a :- r) -> map (\f -> (f, r)) (ss a))
 
 -- | Give all possible parses or errors.
-parse :: forall e a p tok. (InitialPosition e) => Boomerang e tok () a -> tok -> [Either e (a, tok)]
+parse :: forall e a p tok. (InitialPosition e) => Boomerang e tok () a -> tok -> [Either e (a, tok, Pos e)]
 parse p s =
-    map (either Left (\((f, tok), _) -> Right (f (), tok))) $ runParser (prs p) s (initialPos (Nothing :: Maybe e))
+    map (either Left (\((f, tok), pos) -> Right (f (), tok, pos))) $ runParser (prs p) s (initialPos (Nothing :: Maybe e))
 
 -- | Give the first parse, for Boomerangs with a parser that yields just one value.
 -- Otherwise return the error (or errors) with the highest error position.
-parse1 :: (ErrorPosition e, InitialPosition e, Show e, Ord (Pos e)) =>
-          (tok -> Bool) -> Boomerang e tok () (a :- ()) -> tok -> Either [e] a
-parse1 isComplete r paths =
-    let results = parse r paths
-    in case [ a | (Right (a,tok)) <- results, isComplete tok ] of
-         ((u :- ()):_) -> Right u
-         _             -> Left $ bestErrors [ e | Left e <- results ]
+parse1 :: (Error e, ErrorPosition e, InitialPosition e, Show e, Ord (Pos e), Show tok ) => (tok -> Bool) -> Boomerang e tok () (a :- ()) -> tok -> Either [e] a
+parse1 isComplete p s = 
+  case partition (either (const False) (\(_,tok,_) -> isComplete tok )) $
+       parse p s of
+    ( [],             badParsings )  -> bestMsgs Nothing [] badParsings 
+    ( Right ( u :- (), _, _ ):_, _) ->  Right u
+   where 
+    bestMsgs _      errMsgs []     = Left errMsgs
+    bestMsgs errPos errMsgs (x:xs) = case x of 
+      Right ( u :- ()  ,tok, pos) 
+        | justPos > errPos -> bestMsgs justPos (newErrMsg :[]) xs  
+        | otherwise        -> bestMsgs errPos   errMsgs        xs 
+          where 
+            justPos   = Just pos
+            newErrMsg = setPosition pos  $ strMsg $ 
+                        "no parse starting at " ++ (take 10 $ show tok) 
+      Left e  -> let mPos = getPosition e in   
+          case compare mPos errPos of 
+            GT -> bestMsgs mPos   [e]         xs
+            EQ -> bestMsgs mPos   (e:errMsgs) xs 
+            LT -> bestMsgs errPos    errMsgs  xs 
+
 
 -- | Give all possible serializations.
 unparse :: tok -> Boomerang e tok () url -> url -> [tok]


### PR DESCRIPTION
Hi,

I have tried to improve the error messages produced
by parsers in the case of error-less incomplete parsings.
(The example is in the git commit message as well as 
comments on changes done.)

The patch makes the definition of the function "parse1"
more explicit (it doesn't use the functions "bestError" 
and "maximumBy" now) ,  but in this way one avoids 
to go through the list of possible parsings several times.

There is a type change in the function "parse" exported by 
the module Prim.hs, since we need to know the position 
where the parsing stopped when emitting a message in 
the function "parse1". This can be avoided by introducing
a new function "parse' " or putting the corresponding code
inside of the definition of "parse1" . I am not sure what is 
better as of now the function "parse" is not used  in other 
parts of the Boomerang library, and it is unclear to me if 
anybody imports it. (In most cases only the specific parsers
like parseString, parseStrings, parseTexts would be used.) 

Best, 
Ivan

PS. I have run the travis build on my master branch and it 
was successful. 



