### PR TITLE
Allow building with template-haskell-2.17.*

### DIFF
--- a/boomerang.cabal
+++ b/boomerang.cabal
@@ -17,8 +17,9 @@ Library
         Build-Depends:    base             >= 4    && < 5,
                           mtl              >= 2.0  && < 2.3,
                           semigroups       >= 0.16 && < 0.20,
-                          template-haskell            < 2.17,
-                          text             >= 0.11 && < 1.3
+                          template-haskell            < 2.18,
+                          text             >= 0.11 && < 1.3,
+                          th-abstraction   >= 0.4  && < 0.5
         Exposed-Modules:  Text.Boomerang
                           Text.Boomerang.Combinators
                           Text.Boomerang.Error


### PR DESCRIPTION
`template-haskel-2.17.0.0`, which is bundled with GHC 9.0, added a new type parameter to the `TyVarBndr` data type, as well as new fields to its `PlainTV` and `KindedTV` data constructors. (See [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0?version_id=5fcd0a50e0872efb3c38a32db140506da8310d87#template-haskell-217) for more details.) To avoid having to work around these changes with CPP, I've added a dependency on the lightweight `th-abstraction` library, whose `Language.Haskell.TH.Datatype.TyVarBndr` module provides a compatibility shim for working with `TyVarBndr`s before and after `template-haskell-2.17.0.0`.