### PR TITLE
Allow building with `template-haskell-2.18.*`

### DIFF
--- a/Text/Boomerang/TH.hs
+++ b/Text/Boomerang/TH.hs
@@ -97,13 +97,13 @@ deriveDestructor name tys = do
   ConE cons  <- [| (:-) |]
 
 
-  let conPat   = ConP name (map VarP fieldNames)
+  let conPat   = conPCompat name (map VarP fieldNames)
   let okBody   = ConE just `AppE`
                   foldr
                     (\h t -> ConE cons `AppE` VarE h `AppE` t)
                     (VarE r)
                     fieldNames
-  let okCase   = Match (ConP cons [conPat, VarP r]) (NormalB okBody) []
+  let okCase   = Match (conPCompat cons [conPat, VarP r]) (NormalB okBody) []
   let nStr = show name
   let failCase = Match WildP (NormalB nothing) []
 
@@ -123,3 +123,10 @@ conName con =
     RecC name _     -> name
     InfixC _ name _ -> name
     ForallC _ _ con' -> conName con'
+
+conPCompat :: Name -> [Pat] -> Pat
+conPCompat n pats = ConP n
+#if MIN_VERSION_template_haskell(2,18,0)
+                           []
+#endif
+                           pats

--- a/boomerang.cabal
+++ b/boomerang.cabal
@@ -17,7 +17,7 @@ Library
         Build-Depends:    base             >= 4    && < 5,
                           mtl              >= 2.0  && < 2.3,
                           semigroups       >= 0.16 && < 0.20,
-                          template-haskell            < 2.18,
+                          template-haskell            < 2.19,
                           text             >= 0.11 && < 1.3,
                           th-abstraction   >= 0.4  && < 0.5
         Exposed-Modules:  Text.Boomerang


### PR DESCRIPTION
`template-haskell-2.18`, which is bundled with GHC 9.2, added a `[Type]` field to `ConP` to represent visible type arguments. (See [the 9.2 Migration Guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=ad6254b755131de4401bcc73afcb2e6e7542015a#template-haskell-218)). As a result, the uses of `ConP` in `Text.Boomerang.TH` need to be adjusted to allow them to compile with GHC 9.2. I opted to factor out each use of `ConP` into a `conPCompat` function in order to minimize the amount of CPP needed.