### PR TITLE
Allow building with `template-haskell-2.19` (GHC 9.4)

### DIFF
--- a/boomerang.cabal
+++ b/boomerang.cabal
@@ -17,7 +17,7 @@ Library
         Build-Depends:    base             >= 4    && < 5,
                           mtl              >= 2.0  && < 2.3,
                           semigroups       >= 0.16 && < 0.21,
-                          template-haskell            < 2.19,
+                          template-haskell            < 2.20,
                           text             >= 0.11 && < 2.1,
                           th-abstraction   >= 0.4  && < 0.5
         Exposed-Modules:  Text.Boomerang


### PR DESCRIPTION
`boomerang` compiles without issue after raising the upper version bounds on `template-haskell`.