### PR TITLE
Allow building with GHC 9.6

### DIFF
--- a/Text/Boomerang/Error.hs
+++ b/Text/Boomerang/Error.hs
@@ -1,8 +1,10 @@
 -- | An Error handling scheme that can be used with 'Boomerang'
-{-# LANGUAGE DeriveDataTypeable, TypeFamilies #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, TypeFamilies #-}
 module Text.Boomerang.Error where
 
+#if !MIN_VERSION_mtl(2,3,0)
 import Control.Monad.Error (Error(..))
+#endif
 import Data.Data (Data, Typeable)
 import Data.List (intercalate, sort, nub)
 import Text.Boomerang.Prim
@@ -39,8 +41,10 @@ instance ErrorList ParserError where
     listMsg s = [ParserError Nothing (Other s)]
 -}
 
+#if !MIN_VERSION_mtl(2,3,0)
 instance Error (ParserError p) where
     strMsg s = ParserError Nothing [Message s]
+#endif
 
 -- | lift a 'pos' and '[ErrorMsg]' into a parse error
 --

--- a/boomerang.cabal
+++ b/boomerang.cabal
@@ -15,11 +15,11 @@ tested-with:      GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC =
 Library
         Default-Language: Haskell2010
         Build-Depends:    base             >= 4    && < 5,
-                          mtl              >= 2.0  && < 2.3,
+                          mtl              >= 2.0  && < 2.4,
                           semigroups       >= 0.16 && < 0.21,
-                          template-haskell            < 2.20,
+                          template-haskell            < 2.21,
                           text             >= 0.11 && < 2.1,
-                          th-abstraction   >= 0.4  && < 0.5
+                          th-abstraction   >= 0.4  && < 0.6
         Exposed-Modules:  Text.Boomerang
                           Text.Boomerang.Combinators
                           Text.Boomerang.Error


### PR DESCRIPTION
This allows `boomerang` to build with `template-haskell-2.20.*`, `th-abstraction-0.5.*`, and `mtl-2.3.*`. The latter requires using some CPP in `Text.Boomerang.Error`, as `mtl-2.3.*` no longer exports the `Error` class.