### PR TITLE
build with ghc-9.8.2

### DIFF
--- a/Text/Boomerang/TH.hs
+++ b/Text/Boomerang/TH.hs
@@ -42,7 +42,11 @@ derivePrinterParsers = makeBoomerangs
 {-# DEPRECATED derivePrinterParsers "Use makeBoomerangs instead" #-}
 
 -- Derive a router for a single constructor.
+#if MIN_VERSION_template_haskell(2,21,0)
+deriveBoomerang :: (Name, [TyVarBndrVis]) -> Con -> Q [Dec]
+#else
 deriveBoomerang :: (Name, [TyVarBndrUnit]) -> Con -> Q [Dec]
+#endif
 deriveBoomerang (tName, tParams) con =
   case con of
     NormalC name tys -> go name (map snd tys)

--- a/boomerang.cabal
+++ b/boomerang.cabal
@@ -17,7 +17,7 @@ Library
         Build-Depends:    base             >= 4    && < 5,
                           mtl              >= 2.0  && < 2.4,
                           semigroups       >= 0.16 && < 0.21,
-                          template-haskell            < 2.21,
+                          template-haskell            < 2.22,
                           text             >= 0.11 && < 2.2,
                           th-abstraction   >= 0.4  && < 0.7
         Exposed-Modules:  Text.Boomerang


### PR DESCRIPTION
This is the minimum to build with ghc-9.8.
A more ambitious and risky option would be to depend on template-haskell-compat-v0208 and th-abstraction. They should allow removing the `MIN_VERSION_template_haskell` cpp.